### PR TITLE
Allows build in Visual Studio 2012

### DIFF
--- a/neo/game/gamesys/TypeInfo.cpp
+++ b/neo/game/gamesys/TypeInfo.cpp
@@ -27,6 +27,7 @@ If you have questions concerning this license or the applicable additional terms
 */
 
 // This is real evil but allows the code to inspect arbitrary class variables.
+#define _ALLOW_KEYWORD_MACROS
 #define private		public
 #define protected	public
 


### PR DESCRIPTION
Needed to add a #define to allow compilation of game project in Visual Studio 2012. 
This is due to C++11 explicitly forbidding redefining keywords when standard headers are used.
